### PR TITLE
Parse -PdryRun=false via CLI

### DIFF
--- a/src/main/kotlin/guru/stefma/bintrayrelease/PropertyFinder.kt
+++ b/src/main/kotlin/guru/stefma/bintrayrelease/PropertyFinder.kt
@@ -28,7 +28,8 @@ class PropertyFinder(
     }
 
     private fun getBoolean(propertyName: String, defaultValue: Boolean): Boolean {
-        return project.properties[propertyName] as? Boolean ?: defaultValue
+        val value = project.properties[propertyName] as? String ?: return defaultValue
+        return value.toBoolean()
     }
 
 }


### PR DESCRIPTION
PropertyFinder wasn’t able to parse boolean correctly. Until now the `defaultValue` was always returned because the cast to `Boolean` always failed

fixes #27